### PR TITLE
buf lintによるエラー解決

### DIFF
--- a/proto/chatapp/auth/v1/auth_service.proto
+++ b/proto/chatapp/auth/v1/auth_service.proto
@@ -26,9 +26,9 @@ message LogInResponse {
   string refresh_token = 2;
 }
 
-message LogOutRequest {}
+message LogoutRequest {}
 
-message LogOutResponse {}
+message LogoutResponse {}
 
 message RefreshTokenRequest {
   string refresh_token = 1;
@@ -54,7 +54,7 @@ message ResetPasswordResponse {}
 service AuthService {
   rpc SignUp(SignUpRequest) returns (SignUpResponse);
   rpc LogIn(LogInRequest) returns (LogInResponse);
-  rpc Logout(LogOutRequest) returns (LogOutResponse);
+  rpc Logout(LogoutRequest) returns (LogoutResponse);
   rpc RefreshToken(RefreshTokenRequest) returns (RefreshTokenResponse);
   rpc SendPasswordResetEmail(SendPasswordResetEmailRequest) returns (SendPasswordResetEmailResponse);
   rpc ResetPassword(ResetPasswordRequest) returns (ResetPasswordResponse);


### PR DESCRIPTION
# buf lint error
message名・RPC引数・戻り値すべてをLogoutに統一

``` proto
// 旧
message LogOutRequest {}
message LogOutResponse {}

service AuthService {
  ...
  rpc Logout(LogOutRequest) returns (LogOutResponse);
  ...
}

// 新
message LogoutRequest {}
message LogoutResponse {}

service AuthService {
  ...
  rpc Logout(LogoutRequest) returns (LogoutResponse);
  ...
}
```